### PR TITLE
Add Live Systems page (Truth Monitor + Polymarket)

### DIFF
--- a/db/truth-monitor.sql
+++ b/db/truth-monitor.sql
@@ -1,0 +1,68 @@
+-- Truth Monitor + Polymarket shared data model (Supabase/Postgres)
+
+create table if not exists public.truth_signals (
+  id text primary key,
+  ts timestamptz not null,
+  source text not null,
+  topic text,
+  headline text not null,
+  sentiment text,
+  impact numeric,
+  confidence numeric,
+  url text,
+  raw_json jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_truth_signals_ts on public.truth_signals (ts desc);
+create index if not exists idx_truth_signals_source on public.truth_signals (source);
+
+create table if not exists public.truth_snapshots (
+  id bigserial primary key,
+  ts timestamptz not null,
+  system_confidence text,
+  summary text,
+  notable_count int,
+  payload jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_truth_snapshots_ts on public.truth_snapshots (ts desc);
+
+create table if not exists public.polymarket_positions (
+  id bigserial primary key,
+  ts timestamptz not null,
+  wallet text not null,
+  market_slug text not null,
+  market_title text,
+  outcome text,
+  size numeric,
+  initial_value numeric,
+  current_value numeric,
+  cash_pnl numeric,
+  mark_price numeric,
+  payload jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_poly_positions_wallet_ts on public.polymarket_positions (wallet, ts desc);
+
+-- Basic read policy for public dashboard usage
+alter table public.truth_signals enable row level security;
+alter table public.truth_snapshots enable row level security;
+alter table public.polymarket_positions enable row level security;
+
+do $$ begin
+  create policy "public can read truth_signals" on public.truth_signals for select using (true);
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "public can read truth_snapshots" on public.truth_snapshots for select using (true);
+exception when duplicate_object then null;
+end $$;
+
+do $$ begin
+  create policy "public can read polymarket_positions" on public.polymarket_positions for select using (true);
+exception when duplicate_object then null;
+end $$;

--- a/docs/systems-deployment.md
+++ b/docs/systems-deployment.md
@@ -48,6 +48,29 @@ Without these variables, `/systems` falls back to static snapshot file:
 4. Add polymarket snapshot writer (hourly)
 5. Verify `/systems` shows live feed + deltas
 
+## Writer commands
+
+### Truth Monitor writer
+```bash
+cd ~/.openclaw/workspace/truth-monitor
+SUPABASE_URL="https://<project>.supabase.co" \
+SUPABASE_SERVICE_ROLE_KEY="<service-role-key>" \
+python3 supabase_writer.py
+```
+
+### Polymarket writer
+```bash
+cd ~/.openclaw/workspace/polymarket-analyst
+SUPABASE_URL="https://<project>.supabase.co" \
+SUPABASE_SERVICE_ROLE_KEY="<service-role-key>" \
+POLYMARKET_WALLET="0xcF0f71A0e571905D4A6a8915EE26286a5e783cfb" \
+python3 supabase_positions_writer.py
+```
+
+### Suggested cron cadence
+- `truth-monitor/supabase_writer.py`: every 5 minutes
+- `polymarket-analyst/supabase_positions_writer.py`: every 30-60 minutes
+
 ## Security notes
 - Use anon key only for read paths
 - Use service role key only in writer jobs (never in browser)

--- a/docs/systems-deployment.md
+++ b/docs/systems-deployment.md
@@ -1,0 +1,54 @@
+# Systems Data Deployment Plan
+
+## Goal
+Make Truth Monitor + Polymarket data globally consumable (website, bots, agents) with one source of truth.
+
+## Proposed architecture
+1. **System of record:** Supabase Postgres
+2. **Writers:**
+   - `truth-monitor` writes `truth_signals` + `truth_snapshots`
+   - `polymarket` writer writes periodic snapshots into `polymarket_positions`
+3. **Readers:**
+   - Portfolio website reads via Supabase REST (read-only anon key)
+   - Other systems can query SQL or REST directly
+
+## Why this setup
+- Global availability across machines/services
+- Queryable history for analytics + model tuning
+- Decouples UI from local files and process memory
+
+## Environment variables (website)
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+Without these variables, `/systems` falls back to static snapshot file:
+- `public/data/truth-monitor-snapshot.json`
+
+## Deployment options (to decide together)
+
+### Option A — Keep GitHub Pages (current)
+- Website remains static export
+- Browser fetches Supabase directly (already compatible)
+- No server required
+- Best if we want minimal ops
+
+### Option B — Move website to Vercel
+- Enables server routes and edge caching
+- Better control of secrets and transformations
+- Slightly higher ops surface
+
+### Option C — Cloudflare Pages + Workers
+- Similar dynamic capabilities with lower cost profile
+- Good for global edge if feed volume grows
+
+## Recommended immediate rollout
+1. Create Supabase project and run `db/truth-monitor.sql`
+2. Add env vars to website deploy target
+3. Add truth-monitor writer job (every 1-5 min)
+4. Add polymarket snapshot writer (hourly)
+5. Verify `/systems` shows live feed + deltas
+
+## Security notes
+- Use anon key only for read paths
+- Use service role key only in writer jobs (never in browser)
+- Keep PII/secret fields out of public tables

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test tests/**/*.test.mjs"
   },
   "dependencies": {
     "@portabletext/react": "^5.0.0",

--- a/public/data/truth-monitor-snapshot.json
+++ b/public/data/truth-monitor-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "updatedAt": "pending",
+  "systemConfidence": "UNKNOWN",
+  "summary": "Truth Monitor snapshot exporter not connected yet.",
+  "highlights": []
+}

--- a/src/app/systems/page.tsx
+++ b/src/app/systems/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+type PolymarketPosition = {
+  title: string;
+  slug: string;
+  outcome: string;
+  size: number;
+  initialValue: number;
+  currentValue: number;
+  cashPnl: number;
+  curPrice: number;
+  endDate?: string;
+};
+
+type TruthMonitorSnapshot = {
+  updatedAt?: string;
+  systemConfidence?: string;
+  summary?: string;
+  highlights?: string[];
+};
+
+const POLYMARKET_WALLET = "0xcF0f71A0e571905D4A6a8915EE26286a5e783cfb";
+
+export default function SystemsPage() {
+  const [positions, setPositions] = useState<PolymarketPosition[]>([]);
+  const [positionsError, setPositionsError] = useState<string | null>(null);
+  const [truthSnapshot, setTruthSnapshot] = useState<TruthMonitorSnapshot | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(
+          `https://data-api.polymarket.com/positions?user=${POLYMARKET_WALLET}&sizeThreshold=0`,
+          { cache: "no-store" }
+        );
+        if (!res.ok) throw new Error(`Polymarket API error ${res.status}`);
+        const data: PolymarketPosition[] = await res.json();
+        setPositions(data.filter((p) => Number(p.size) > 0));
+      } catch (e) {
+        setPositionsError(e instanceof Error ? e.message : "Failed to load positions");
+      }
+
+      try {
+        const snapshotRes = await fetch("/data/truth-monitor-snapshot.json", {
+          cache: "no-store",
+        });
+        if (snapshotRes.ok) {
+          const snapshot = (await snapshotRes.json()) as TruthMonitorSnapshot;
+          setTruthSnapshot(snapshot);
+        }
+      } catch {
+        // optional surface; ignore silently
+      }
+    };
+
+    load();
+  }, []);
+
+  const stats = useMemo(() => {
+    const totalInitial = positions.reduce((acc, p) => acc + Number(p.initialValue || 0), 0);
+    const totalCurrent = positions.reduce((acc, p) => acc + Number(p.currentValue || 0), 0);
+    const totalPnl = positions.reduce((acc, p) => acc + Number(p.cashPnl || 0), 0);
+    const red = positions.filter((p) => Number(p.cashPnl || 0) < 0).length;
+    const green = positions.filter((p) => Number(p.cashPnl || 0) > 0).length;
+
+    return { totalInitial, totalCurrent, totalPnl, red, green };
+  }, [positions]);
+
+  const topLosses = useMemo(
+    () => [...positions].sort((a, b) => Number(a.cashPnl) - Number(b.cashPnl)).slice(0, 5),
+    [positions]
+  );
+
+  return (
+    <main className="container mx-auto max-w-4xl py-12 px-6 md:px-0 space-y-8">
+      <section className="space-y-2">
+        <h1 className="text-3xl md:text-4xl font-bold tracking-tight">Live Systems</h1>
+        <p className="text-muted-foreground">
+          Real-time view of Truth Monitor signals and Polymarket active positions.
+        </p>
+      </section>
+
+      <Card className="border">
+        <CardHeader>
+          <CardTitle className="text-xl">Truth Monitor</CardTitle>
+          <CardDescription>Public-facing snapshot from the local monitor pipeline.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {truthSnapshot ? (
+            <>
+              <p>
+                <span className="font-medium text-foreground">System confidence:</span>{" "}
+                {truthSnapshot.systemConfidence || "Unknown"}
+              </p>
+              <p>
+                <span className="font-medium text-foreground">Summary:</span>{" "}
+                {truthSnapshot.summary || "No summary provided."}
+              </p>
+              {!!truthSnapshot.highlights?.length && (
+                <ul className="list-disc pl-6 space-y-1">
+                  {truthSnapshot.highlights.map((h) => (
+                    <li key={h}>{h}</li>
+                  ))}
+                </ul>
+              )}
+              <p className="text-xs">Updated: {truthSnapshot.updatedAt || "Unknown"}</p>
+            </>
+          ) : (
+            <p>
+              Snapshot not published yet. Wire your local monitor to update
+              <code className="mx-1">/public/data/truth-monitor-snapshot.json</code>.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border">
+        <CardHeader>
+          <CardTitle className="text-xl">Polymarket — Active Positions</CardTitle>
+          <CardDescription>
+            Wallet: <code>{POLYMARKET_WALLET}</code>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {positionsError && <p className="text-red-500">{positionsError}</p>}
+
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+            <div>
+              <p className="text-muted-foreground">Positions</p>
+              <p className="text-foreground font-semibold">{positions.length}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Green / Red</p>
+              <p className="text-foreground font-semibold">{stats.green} / {stats.red}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Initial</p>
+              <p className="text-foreground font-semibold">${stats.totalInitial.toFixed(2)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Current</p>
+              <p className="text-foreground font-semibold">${stats.totalCurrent.toFixed(2)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">uPnL</p>
+              <p className={`font-semibold ${stats.totalPnl >= 0 ? "text-green-500" : "text-red-500"}`}>
+                ${stats.totalPnl.toFixed(2)}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className="font-medium text-foreground">Top 5 drawdowns</p>
+            {topLosses.map((p) => (
+              <div key={`${p.slug}-${p.outcome}`} className="rounded-md border p-3 text-sm">
+                <p className="text-foreground font-medium">{p.title}</p>
+                <p className="text-muted-foreground">
+                  {p.outcome} · size {Number(p.size).toFixed(2)} · mark {(Number(p.curPrice) * 100).toFixed(1)}¢
+                </p>
+                <p className="text-red-500">uPnL ${Number(p.cashPnl).toFixed(2)}</p>
+              </div>
+            ))}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Data source: Polymarket Data API (public) · live client fetch
+          </p>
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-muted-foreground">
+        Want this to auto-refresh from your local truth-monitor process? I can wire a lightweight exporter + cron push next.
+      </p>
+
+      <Link href="/" className="text-sm underline">← Back home</Link>
+    </main>
+  );
+}

--- a/src/app/systems/page.tsx
+++ b/src/app/systems/page.tsx
@@ -14,7 +14,6 @@ type PolymarketPosition = {
   currentValue: number;
   cashPnl: number;
   curPrice: number;
-  endDate?: string;
 };
 
 type TruthMonitorSnapshot = {
@@ -39,36 +38,94 @@ const POLYMARKET_WALLET = "0xcF0f71A0e571905D4A6a8915EE26286a5e783cfb";
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
+const supabaseHeaders =
+  SUPABASE_ANON_KEY
+    ? {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      }
+    : undefined;
+
+const hasSupabase = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+
+function mapDbPosition(row: any): PolymarketPosition {
+  return {
+    title: row.market_title ?? "Unknown market",
+    slug: row.market_slug ?? "unknown",
+    outcome: row.outcome ?? "Unknown",
+    size: Number(row.size ?? 0),
+    initialValue: Number(row.initial_value ?? 0),
+    currentValue: Number(row.current_value ?? 0),
+    cashPnl: Number(row.cash_pnl ?? 0),
+    curPrice: Number(row.mark_price ?? 0),
+  };
+}
+
 export default function SystemsPage() {
   const [positions, setPositions] = useState<PolymarketPosition[]>([]);
   const [positionsError, setPositionsError] = useState<string | null>(null);
   const [truthSnapshot, setTruthSnapshot] = useState<TruthMonitorSnapshot | null>(null);
   const [truthSignals, setTruthSignals] = useState<TruthSignal[]>([]);
+  const [positionSource, setPositionSource] = useState("Polymarket Data API (public)");
 
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch(
-          `https://data-api.polymarket.com/positions?user=${POLYMARKET_WALLET}&sizeThreshold=0`,
-          { cache: "no-store" }
-        );
-        if (!res.ok) throw new Error(`Polymarket API error ${res.status}`);
-        const data: PolymarketPosition[] = await res.json();
-        setPositions(data.filter((p) => Number(p.size) > 0));
+        let loadedFromSupabase = false;
+
+        if (hasSupabase) {
+          const latestTsRes = await fetch(
+            `${SUPABASE_URL}/rest/v1/polymarket_positions?select=ts&wallet=eq.${POLYMARKET_WALLET}&order=ts.desc&limit=1`,
+            { cache: "no-store", headers: supabaseHeaders }
+          );
+
+          if (latestTsRes.ok) {
+            const latest = await latestTsRes.json();
+            const latestTs = latest?.[0]?.ts;
+            if (latestTs) {
+              const posRes = await fetch(
+                `${SUPABASE_URL}/rest/v1/polymarket_positions?select=market_slug,market_title,outcome,size,initial_value,current_value,cash_pnl,mark_price&wallet=eq.${POLYMARKET_WALLET}&ts=eq.${encodeURIComponent(
+                  latestTs
+                )}`,
+                { cache: "no-store", headers: supabaseHeaders }
+              );
+
+              if (posRes.ok) {
+                const rows = await posRes.json();
+                const mapped = (rows || []).map(mapDbPosition);
+                if (mapped.length) {
+                  setPositions(mapped);
+                  setPositionSource("Supabase (polymarket_positions)");
+                  loadedFromSupabase = true;
+                }
+              }
+            }
+          }
+        }
+
+        if (!loadedFromSupabase) {
+          const res = await fetch(
+            `https://data-api.polymarket.com/positions?user=${POLYMARKET_WALLET}&sizeThreshold=0`,
+            { cache: "no-store" }
+          );
+          if (!res.ok) throw new Error(`Polymarket API error ${res.status}`);
+          const data: PolymarketPosition[] = await res.json();
+          setPositions(data.filter((p) => Number(p.size) > 0));
+          setPositionSource("Polymarket Data API (public)");
+        }
       } catch (e) {
         setPositionsError(e instanceof Error ? e.message : "Failed to load positions");
       }
 
       try {
-        if (SUPABASE_URL && SUPABASE_ANON_KEY) {
+        let loadedSnapshotFromSupabase = false;
+
+        if (hasSupabase) {
           const feedRes = await fetch(
             `${SUPABASE_URL}/rest/v1/truth_signals?select=id,ts,source,headline,sentiment,impact,confidence,url&order=ts.desc&limit=8`,
             {
               cache: "no-store",
-              headers: {
-                apikey: SUPABASE_ANON_KEY,
-                Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
-              },
+              headers: supabaseHeaders,
             }
           );
 
@@ -76,14 +133,35 @@ export default function SystemsPage() {
             const rows = (await feedRes.json()) as TruthSignal[];
             setTruthSignals(rows);
           }
+
+          const snapRes = await fetch(
+            `${SUPABASE_URL}/rest/v1/truth_snapshots?select=ts,system_confidence,summary,payload&order=ts.desc&limit=1`,
+            { cache: "no-store", headers: supabaseHeaders }
+          );
+
+          if (snapRes.ok) {
+            const rows = await snapRes.json();
+            const r = rows?.[0];
+            if (r) {
+              setTruthSnapshot({
+                updatedAt: r.ts,
+                systemConfidence: r.system_confidence,
+                summary: r.summary,
+                highlights: r?.payload?.highlights ?? [],
+              });
+              loadedSnapshotFromSupabase = true;
+            }
+          }
         }
 
-        const snapshotRes = await fetch("/data/truth-monitor-snapshot.json", {
-          cache: "no-store",
-        });
-        if (snapshotRes.ok) {
-          const snapshot = (await snapshotRes.json()) as TruthMonitorSnapshot;
-          setTruthSnapshot(snapshot);
+        if (!loadedSnapshotFromSupabase) {
+          const snapshotRes = await fetch("/data/truth-monitor-snapshot.json", {
+            cache: "no-store",
+          });
+          if (snapshotRes.ok) {
+            const snapshot = (await snapshotRes.json()) as TruthMonitorSnapshot;
+            setTruthSnapshot(snapshot);
+          }
         }
       } catch {
         // optional surface; ignore silently
@@ -91,36 +169,32 @@ export default function SystemsPage() {
     };
 
     load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const stats = useMemo(() => summarizePositions(positions), [positions]);
-
   const topLosses = useMemo(() => rankTopLosses(positions, 5), [positions]);
 
   return (
     <main className="container mx-auto max-w-4xl py-12 px-6 md:px-0 space-y-8">
       <section className="space-y-2">
         <h1 className="text-3xl md:text-4xl font-bold tracking-tight">Live Systems</h1>
-        <p className="text-muted-foreground">
-          Real-time view of Truth Monitor signals and Polymarket active positions.
-        </p>
+        <p className="text-muted-foreground">Real-time view of Truth Monitor signals and Polymarket active positions.</p>
       </section>
 
       <Card className="border">
         <CardHeader>
           <CardTitle className="text-xl">Truth Monitor</CardTitle>
-          <CardDescription>Public-facing snapshot from the local monitor pipeline.</CardDescription>
+          <CardDescription>Supabase-first feed with static snapshot fallback.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-2">
           {truthSnapshot ? (
             <>
               <p>
-                <span className="font-medium text-foreground">System confidence:</span>{" "}
-                {truthSnapshot.systemConfidence || "Unknown"}
+                <span className="font-medium text-foreground">System confidence:</span> {truthSnapshot.systemConfidence || "Unknown"}
               </p>
               <p>
-                <span className="font-medium text-foreground">Summary:</span>{" "}
-                {truthSnapshot.summary || "No summary provided."}
+                <span className="font-medium text-foreground">Summary:</span> {truthSnapshot.summary || "No summary provided."}
               </p>
               {!!truthSnapshot.highlights?.length && (
                 <ul className="list-disc pl-6 space-y-1">
@@ -202,18 +276,17 @@ export default function SystemsPage() {
             ))}
           </div>
 
-          <p className="text-xs text-muted-foreground">
-            Data source: Polymarket Data API (public) · live client fetch
-          </p>
+          <p className="text-xs text-muted-foreground">Data source: {positionSource}</p>
         </CardContent>
       </Card>
 
       <p className="text-xs text-muted-foreground">
-        This page is Supabase-ready via <code>NEXT_PUBLIC_SUPABASE_URL</code> + <code>NEXT_PUBLIC_SUPABASE_ANON_KEY</code>,
-        with static snapshot fallback for local/dev.
+        Supabase-ready via <code>NEXT_PUBLIC_SUPABASE_URL</code> + <code>NEXT_PUBLIC_SUPABASE_ANON_KEY</code>, with static/public fallback.
       </p>
 
-      <Link href="/" className="text-sm underline">← Back home</Link>
+      <Link href="/" className="text-sm underline">
+        ← Back home
+      </Link>
     </main>
   );
 }

--- a/src/app/systems/page.tsx
+++ b/src/app/systems/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { rankTopLosses, summarizePositions } from "@/lib/systems-data.mjs";
 
 type PolymarketPosition = {
   title: string;
@@ -23,12 +24,26 @@ type TruthMonitorSnapshot = {
   highlights?: string[];
 };
 
+type TruthSignal = {
+  id: string;
+  ts: string;
+  source: string;
+  headline: string;
+  sentiment?: string;
+  impact?: number;
+  confidence?: number;
+  url?: string;
+};
+
 const POLYMARKET_WALLET = "0xcF0f71A0e571905D4A6a8915EE26286a5e783cfb";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 export default function SystemsPage() {
   const [positions, setPositions] = useState<PolymarketPosition[]>([]);
   const [positionsError, setPositionsError] = useState<string | null>(null);
   const [truthSnapshot, setTruthSnapshot] = useState<TruthMonitorSnapshot | null>(null);
+  const [truthSignals, setTruthSignals] = useState<TruthSignal[]>([]);
 
   useEffect(() => {
     const load = async () => {
@@ -45,6 +60,24 @@ export default function SystemsPage() {
       }
 
       try {
+        if (SUPABASE_URL && SUPABASE_ANON_KEY) {
+          const feedRes = await fetch(
+            `${SUPABASE_URL}/rest/v1/truth_signals?select=id,ts,source,headline,sentiment,impact,confidence,url&order=ts.desc&limit=8`,
+            {
+              cache: "no-store",
+              headers: {
+                apikey: SUPABASE_ANON_KEY,
+                Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+              },
+            }
+          );
+
+          if (feedRes.ok) {
+            const rows = (await feedRes.json()) as TruthSignal[];
+            setTruthSignals(rows);
+          }
+        }
+
         const snapshotRes = await fetch("/data/truth-monitor-snapshot.json", {
           cache: "no-store",
         });
@@ -60,20 +93,9 @@ export default function SystemsPage() {
     load();
   }, []);
 
-  const stats = useMemo(() => {
-    const totalInitial = positions.reduce((acc, p) => acc + Number(p.initialValue || 0), 0);
-    const totalCurrent = positions.reduce((acc, p) => acc + Number(p.currentValue || 0), 0);
-    const totalPnl = positions.reduce((acc, p) => acc + Number(p.cashPnl || 0), 0);
-    const red = positions.filter((p) => Number(p.cashPnl || 0) < 0).length;
-    const green = positions.filter((p) => Number(p.cashPnl || 0) > 0).length;
+  const stats = useMemo(() => summarizePositions(positions), [positions]);
 
-    return { totalInitial, totalCurrent, totalPnl, red, green };
-  }, [positions]);
-
-  const topLosses = useMemo(
-    () => [...positions].sort((a, b) => Number(a.cashPnl) - Number(b.cashPnl)).slice(0, 5),
-    [positions]
-  );
+  const topLosses = useMemo(() => rankTopLosses(positions, 5), [positions]);
 
   return (
     <main className="container mx-auto max-w-4xl py-12 px-6 md:px-0 space-y-8">
@@ -108,6 +130,20 @@ export default function SystemsPage() {
                 </ul>
               )}
               <p className="text-xs">Updated: {truthSnapshot.updatedAt || "Unknown"}</p>
+
+              {!!truthSignals.length && (
+                <div className="pt-2 space-y-2">
+                  <p className="font-medium text-foreground">Latest signals</p>
+                  {truthSignals.map((s) => (
+                    <div key={s.id} className="rounded border p-2 text-xs">
+                      <p className="text-foreground">{s.headline}</p>
+                      <p className="text-muted-foreground">
+                        {s.source} · {s.sentiment || "neutral"} · impact {s.impact ?? "n/a"} · conf {s.confidence ?? "n/a"}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </>
           ) : (
             <p>
@@ -131,7 +167,7 @@ export default function SystemsPage() {
           <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
             <div>
               <p className="text-muted-foreground">Positions</p>
-              <p className="text-foreground font-semibold">{positions.length}</p>
+              <p className="text-foreground font-semibold">{stats.count}</p>
             </div>
             <div>
               <p className="text-muted-foreground">Green / Red</p>
@@ -173,7 +209,8 @@ export default function SystemsPage() {
       </Card>
 
       <p className="text-xs text-muted-foreground">
-        Want this to auto-refresh from your local truth-monitor process? I can wire a lightweight exporter + cron push next.
+        This page is Supabase-ready via <code>NEXT_PUBLIC_SUPABASE_URL</code> + <code>NEXT_PUBLIC_SUPABASE_ANON_KEY</code>,
+        with static snapshot fallback for local/dev.
       </p>
 
       <Link href="/" className="text-sm underline">← Back home</Link>

--- a/src/app/systems/page.tsx
+++ b/src/app/systems/page.tsx
@@ -48,7 +48,18 @@ const supabaseHeaders =
 
 const hasSupabase = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
-function mapDbPosition(row: any): PolymarketPosition {
+type DbPolymarketRow = {
+  market_slug?: string;
+  market_title?: string;
+  outcome?: string;
+  size?: number | string;
+  initial_value?: number | string;
+  current_value?: number | string;
+  cash_pnl?: number | string;
+  mark_price?: number | string;
+};
+
+function mapDbPosition(row: DbPolymarketRow): PolymarketPosition {
   return {
     title: row.market_title ?? "Unknown market",
     slug: row.market_slug ?? "unknown",

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -1,5 +1,5 @@
 import { Icons } from "@/components/icons";
-import { Briefcase, HomeIcon, NotebookIcon } from "lucide-react";
+import { ActivityIcon, Briefcase, HomeIcon, NotebookIcon } from "lucide-react";
 
 export const DATA = {
   name: "Nicholas Chen",
@@ -38,6 +38,7 @@ export const DATA = {
     { href: "/", icon: HomeIcon, label: "Home" },
     { href: "/blog", icon: NotebookIcon, label: "Blog" },
     { href: "/investments", icon: Briefcase, label: "Angel" },
+    { href: "/systems", icon: ActivityIcon, label: "Live Systems" },
   ],
   contact: {
     email: "m@nixholas.me",

--- a/src/lib/systems-data.mjs
+++ b/src/lib/systems-data.mjs
@@ -1,0 +1,24 @@
+const n = (v) => Number(v || 0);
+
+export function summarizePositions(positions = []) {
+  const totalInitial = positions.reduce((acc, p) => acc + n(p.initialValue), 0);
+  const totalCurrent = positions.reduce((acc, p) => acc + n(p.currentValue), 0);
+  const totalPnl = positions.reduce((acc, p) => acc + n(p.cashPnl), 0);
+  const red = positions.filter((p) => n(p.cashPnl) < 0).length;
+  const green = positions.filter((p) => n(p.cashPnl) > 0).length;
+
+  return {
+    count: positions.length,
+    red,
+    green,
+    totalInitial,
+    totalCurrent,
+    totalPnl,
+  };
+}
+
+export function rankTopLosses(positions = [], limit = 5) {
+  return [...positions]
+    .sort((a, b) => n(a.cashPnl) - n(b.cashPnl))
+    .slice(0, limit);
+}

--- a/tests/systems-data.test.mjs
+++ b/tests/systems-data.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { summarizePositions, rankTopLosses } from "../src/lib/systems-data.mjs";
+
+test("summarizePositions computes totals and red/green counts", () => {
+  const rows = [
+    { initialValue: 100, currentValue: 120, cashPnl: 20 },
+    { initialValue: 80, currentValue: 50, cashPnl: -30 },
+    { initialValue: 20, currentValue: 10, cashPnl: -10 },
+  ];
+
+  const result = summarizePositions(rows);
+
+  assert.equal(result.count, 3);
+  assert.equal(result.green, 1);
+  assert.equal(result.red, 2);
+  assert.equal(result.totalInitial, 200);
+  assert.equal(result.totalCurrent, 180);
+  assert.equal(result.totalPnl, -20);
+});
+
+test("rankTopLosses returns most negative pnl first", () => {
+  const rows = [
+    { title: "A", cashPnl: -1.5 },
+    { title: "B", cashPnl: -10 },
+    { title: "C", cashPnl: 5 },
+    { title: "D", cashPnl: -3 },
+  ];
+
+  const result = rankTopLosses(rows, 2);
+
+  assert.equal(result.length, 2);
+  assert.equal(result[0].title, "B");
+  assert.equal(result[1].title, "D");
+});


### PR DESCRIPTION
## What this ships
- Adds a new `/systems` page for live system visibility
- Integrates public Polymarket Data API for active positions (wallet `0xcF0f...3cfb`)
- Adds portfolio-level stats (position count, green/red, initial/current, uPnL)
- Shows top-5 drawdowns
- Adds Truth Monitor snapshot block from `/public/data/truth-monitor-snapshot.json`
- Adds `Live Systems` icon to dock navbar

## Notes
- Truth Monitor snapshot is currently a placeholder file and is ready for exporter wiring.
- This is a kickstart so we can iterate quickly on layout + data granularity.

## Follow-up (I can do next)
- Wire local truth-monitor exporter + cron push to keep snapshot fresh
- Add browser wallet position integration if we expose that wallet data feed
- Add historical sparkline and daily PnL delta
