### PR TITLE
[codex] provide Sanity env to Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SANITY_PROJECT_ID: l916xe0p
+      NEXT_PUBLIC_SANITY_DATASET: production
     steps:
       - uses: actions/checkout@v4
       
@@ -37,4 +40,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out
-          publish_branch: gh-pages 
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary

- Add the public Sanity project ID and dataset to the GitHub Pages workflow environment.
- Fix trailing whitespace at the end of the workflow file.

## Validation

- `./node_modules/.bin/next build`

## Context

The portfolio/blog Vercel deployments are already green, but the custom GitHub Pages workflow failed because Actions did not have `NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET`.