### PR TITLE
[codex] render Sanity blog content dynamically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,13 @@
-name: Deploy to GitHub Pages
+name: Build
 
 on:
+  pull_request:
   push:
-    branches: [ master ]  # Set this to your default branch
+    branches: [ master ]
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   build:
@@ -34,10 +33,3 @@ jobs:
         
       - name: Build with Next.js
         run: pnpm build
-        
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages

--- a/BLOG_GUIDE.md
+++ b/BLOG_GUIDE.md
@@ -8,8 +8,7 @@ Your portfolio site now has a fully functional, optimized blog powered by Sanity
 ### Data Fetching
 - **Blog List**: Only fetches `title`, `slug`, `excerpt`, `publishedAt`, and `mainImage` (no body content)
 - **Individual Posts**: Fetches full content only when needed
-- **Caching**: Enabled force-cache with tags for optimal performance
-- **Result**: Build time reduced from 4.7s to 726ms (6x faster)
+- **Freshness**: Blog routes fetch Sanity at request time with `no-store`, so published Sanity edits do not require a rebuild
 
 ### Query Optimization
 ```typescript
@@ -91,10 +90,8 @@ SANITY_API_TOKEN="your-token-here"
 # Development
 pnpm dev
 
-# Production build (for GitHub Pages)
+# Production build
 pnpm build
-
-# Output will be in ./out directory (ready for GitHub Pages)
 ```
 
 ## Schema Fields
@@ -118,11 +115,12 @@ pnpm build
 
 ## Cache Management
 
-The blog uses Next.js caching with tags:
-- `posts`: All blog posts list
-- `post:${slug}`: Individual post cache
+The public blog intentionally bypasses Next.js fetch caching for Sanity content:
+- `/blog` uses dynamic rendering and fetches the latest published post list
+- `/blog/[slug]` uses dynamic rendering and fetches the latest published body
 
-To revalidate cache after updates, rebuild your site or implement ISR (when not using static export).
+Publishing in Sanity should be reflected on the public Vercel site without a
+code rebuild.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built with next.js, [shadcn/ui](https://ui.shadcn.com/), and [magic ui](https://
 # Features
 
 - Setup only takes a few minutes by editing the [single config file](./src/data/resume.tsx)
-- Built using Next.js 14, React, Typescript, Shadcn/UI, TailwindCSS, Framer Motion, Magic UI
+- Built using Next.js 16, React, Typescript, Shadcn/UI, TailwindCSS, Framer Motion, Magic UI
 - Includes a blog
 - Responsive for different devices
 - Optimized for Next.js and Vercel

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',  // Enable static exports
   images: {
-    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import {
   formatPostDate,
-  getAllPosts,
   getPost,
 } from "@/data/blog";
 import { DATA } from "@/data/resume";
@@ -11,10 +10,9 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { PortableText } from "@portabletext/react";
 
-export async function generateStaticParams() {
-  const posts = await getAllPosts();
-  return posts.map((post) => ({ slug: post.slug.current }));
-}
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
 export async function generateMetadata({
   params,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,6 +10,10 @@ export const metadata = {
     "Notes on software, startups, blockchains, investing, and the edges between them.",
 };
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 const BLUR_FADE_DELAY = 0.04;
 
 export default async function BlogPage() {

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -38,8 +38,7 @@ export async function getAllPosts(): Promise<
     }`,
     {},
     {
-      cache: "force-cache",
-      next: { tags: ["posts"] },
+      cache: "no-store",
     }
   );
 }
@@ -62,8 +61,7 @@ export async function getPost(slug: string): Promise<SanityPost | null> {
     }`,
     { slug },
     {
-      cache: "force-cache",
-      next: { tags: [`post:${slug}`] },
+      cache: "no-store",
     }
   );
 }

--- a/src/data/github.ts
+++ b/src/data/github.ts
@@ -46,7 +46,7 @@ export type GitHubRepo = {
 const REPO_NOTES: Record<string, RepoNote> = {
   "nixxholas.github.io": {
     summary:
-      "This portfolio itself: a static Next.js and Sanity surface for writing, investing notes, and project history.",
+      "This portfolio itself: a Next.js and Sanity surface for writing, investing notes, and project history.",
     tags: ["portfolio", "next.js", "sanity"],
   },
   "delta-neutral-engine": {


### PR DESCRIPTION
## What changed

- Removed Next static export mode from the public blog app.
- Removed `generateStaticParams()` from blog post pages so slugs are resolved dynamically.
- Forced `/blog` and `/blog/[slug]` to render dynamically with no fetch cache.
- Switched Sanity post queries from `force-cache` to `no-store`.
- Converted the old GitHub Pages deploy workflow into a build check, since the public blog is deployed by Vercel.
- Updated blog docs to reflect Sanity/Vercel dynamic rendering.

## Why

Sanity had the published long Asgard post, but the public page was still serving the old build-time body:

- Sanity published body: 36 blocks, about 10k characters.
- Current production page before this change: one sentence, about 51 characters.

The root cause was the static export/build-time data path. Sanity edits should not require a code rebuild to appear on `nixholas.me`.

## Validation

- `npm view next version` returned `16.2.9`, so no Next upgrade is currently needed.
- `./node_modules/.bin/eslint src/`
- `./node_modules/.bin/next build`
- Build output shows `/blog` and `/blog/[slug]` as `ƒ Dynamic`.
- Local production server rendered the long Asgard body from Sanity: about 10.5k characters.